### PR TITLE
Fix get all albums from cached results

### DIFF
--- a/aioimmich/albums/__init__.py
+++ b/aioimmich/albums/__init__.py
@@ -17,8 +17,7 @@ class ImmichAlbums(ImmichSubApi):
         assert isinstance(result, list)
         result_shared = await self.api.async_do_request("albums", {"shared": "true"})
         assert isinstance(result_shared, list)
-        result.extend(result_shared)
-        return [ImmichAlbum.from_dict(album) for album in result]
+        return [ImmichAlbum.from_dict(album) for album in result + result_shared]
 
     async def async_get_album_info(
         self, album_id: str, without_assests: bool = False


### PR DESCRIPTION
We extended the first result with the second one, but as the first result comes from the cache, the cache object got extended every time and those duplicated the shared albums into it.

ref. https://github.com/home-assistant/core/issues/169866